### PR TITLE
Add jm-rivera to recipe maintainers list

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -53,3 +53,4 @@ about:
 extra:
   recipe-maintainers:
     - brynpickering
+    - jm-rivera


### PR DESCRIPTION
This pull request adds a new recipe maintainer to the `recipe.yaml` file.

* Added `jm-rivera` to the `recipe-maintainers` list in `recipe/recipe.yaml`.
@brynpickering 